### PR TITLE
Fastify Deprecation fix

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -23,7 +23,7 @@ const prismaClient: FastifyPluginCallback<FastifyPrismaClientOptions> = async (
 
   fastify
     .decorate("prisma", prisma)
-    .decorateRequest("prisma", fastify.prisma)
+    .decorateRequest("prisma", { getter: () => fastify.prisma })
     .addHook("onClose", async (fastify, done) => {
       await fastify.prisma.$disconnect();
       done();


### PR DESCRIPTION
[FSTDEP006] FastifyDeprecation: You are decorating Request/Reply with a reference type. This reference is shared amongst all requests. Use onRequest hook instead. Property: prisma

reference : https://github.com/fastify/fastify-request-context/issues/30